### PR TITLE
Switch to peerDependencies and update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "build": "./node_modules/.bin/grunt build"
   },
   "description": "Angular-Formly plugin which outputs plain html form fields.",
-  "dependencies": {
-    "angular": "^1.2.22",
-    "angular-formly": "^2.0.0"
+  "peerDependencies": {
+    "angular": "^1.x",
+    "angular-formly": ">=3.0.0"
   },
   "devDependencies": {
     "bower": "1.2.7",


### PR DESCRIPTION
This way people can have their own version of angular and angular-formly and they wont be loading it into the browser twice.
