### PR TITLE
Adding ion radio with balanced class for ion-checkmark ionicon

### DIFF
--- a/dist/angular-formly-templates-ionic.js
+++ b/dist/angular-formly-templates-ionic.js
@@ -2,7 +2,7 @@ angular.module('formlyIonic', ['formly'], ["formlyConfigProvider", function conf
   'use strict';
 
 
-  angular.forEach(['checkbox','input','radio', 'radio-ion-checkmark-balanced', 'range','textarea','toggle'], function(fieldName) {
+  angular.forEach(['checkbox','input','radio','radio-ion-checkmark-balanced','range','textarea','toggle'], function(fieldName) {
     formlyConfigProvider.setType({
       name: fieldName,
       templateUrl: getFieldTemplateUrl(fieldName),

--- a/dist/angular-formly-templates-ionic.js
+++ b/dist/angular-formly-templates-ionic.js
@@ -2,7 +2,7 @@ angular.module('formlyIonic', ['formly'], ["formlyConfigProvider", function conf
   'use strict';
 
 
-  angular.forEach(['checkbox','input','radio', 'range','textarea','toggle'], function(fieldName) {
+  angular.forEach(['checkbox','input','radio', 'radio-ion-checkmark-balanced', 'range','textarea','toggle'], function(fieldName) {
     formlyConfigProvider.setType({
       name: fieldName,
       templateUrl: getFieldTemplateUrl(fieldName),
@@ -43,6 +43,7 @@ angular.module('formlyIonic', ['formly'], ["formlyConfigProvider", function conf
 angular.module("formlyIonic").run(["$templateCache", function($templateCache) {$templateCache.put("fields/ion-checkbox.html","<ion-checkbox ng-model=\"model[options.key]\">{{options.templateOptions.label}}</ion-checkbox>");
 $templateCache.put("fields/ion-input.html","<label class=\"item item-input\"><input ng-model=\"model[options.key]\" placeholder=\"{{options.templateOptions.placeholder}}\" type=\"{{options.templateOptions.type}}\"></label>");
 $templateCache.put("fields/ion-radio.html","<ion-radio ng-repeat=\"item in options.templateOptions.list\" ng-value=\"item.value\" ng-model=\"model[options.key]\">{{ item.text }}</ion-radio>");
+$templateCache.put("fields/ion-radio-ion-checkmark-balanced.html","<ion-radio icon=\"ion-checkmark balanced\" ng-repeat=\"item in options.templateOptions.list\" ng-value=\"item.value\" ng-model=\"model[options.key]\">{{ item.text }}</ion-radio>");
 $templateCache.put("fields/ion-range.html","<div class=\"item range\" ng-class=\"\'range-\' + options.templateOptions.rangeClass\"><span>{{options.templateOptions.label}}</span> <i class=\"icon\" ng-if=\"options.templateOptions.minIcon\" ng-class=\"options.templateOptions.minIcon\"></i> <input type=\"range\" min=\"{{options.templateOptions.min}}\" max=\"{{options.templateOptions.max}}\" step=\"{{options.templateOptions.step}}\" value=\"{{options.templateOptions.value}}\" ng-model=\"model[options.key]\"> <i class=\"icon\" ng-if=\"options.templateOptions.maxIcon\" ng-class=\"options.templateOptions.maxIcon\"></i></div>");
 $templateCache.put("fields/ion-textarea.html","<label class=\"item item-input\"><textarea placeholder=\"{{options.templateOptions.placeholder}}\" ng-model=\"model[options.key]\"></textarea></label>");
 $templateCache.put("fields/ion-toggle.html","<ion-toggle ng-model=\"model[options.key]\" toggle-class=\"toggle-{{options.templateOptions.toggleClass}}\">{{options.templateOptions.label}}</ion-toggle>");}]);

--- a/examples/default/www/js/angular-formly-templates-ionic.js
+++ b/examples/default/www/js/angular-formly-templates-ionic.js
@@ -1,1 +1,49 @@
-/Users/mhartington/GithubRepos/angular-formly/angular-formly-templates-ionic/dist/angular-formly-templates-ionic.js
+angular.module('formlyIonic', ['formly'], ["formlyConfigProvider", function configFormlyIonic(formlyConfigProvider) {
+  'use strict';
+
+
+  angular.forEach(['checkbox','input','radio','radio-ion-checkmark-balanced','range','textarea','toggle'], function(fieldName) {
+    formlyConfigProvider.setType({
+      name: fieldName,
+      templateUrl: getFieldTemplateUrl(fieldName),
+
+    });
+  });
+
+  formlyConfigProvider.templateManipulators.preWrapper.push(function ariaDescribedBy(template, options, scope) {
+    if (options.templateOptions && angular.isDefined(options.templateOptions.description) &&
+      options.type !== 'radio' && options.type !== 'checkbox') {
+      var el = angular.element('<a></a>');
+      el.append(template);
+      var modelEls = angular.element(el[0].querySelectorAll('[ng-model]'));
+      if (modelEls) {
+        el.append(
+          '<p id="' + scope.id + '_description"' +
+              'class="help-block"' +
+              'ng-if="options.templateOptions.description">' +
+            '{{options.templateOptions.description}}' +
+          '</p>'
+        );
+        modelEls.attr('aria-describedby', scope.id + '_description');
+        return el.html();
+      } else {
+        return template;
+      }
+    } else {
+      return template;
+    }
+  });
+
+  function getFieldTemplateUrl(name) {
+    return 'fields/ion-' + name + '.html';
+  }
+
+}]);
+
+angular.module("formlyIonic").run(["$templateCache", function($templateCache) {$templateCache.put("fields/ion-checkbox.html","<ion-checkbox ng-model=\"model[options.key]\">{{options.templateOptions.label}}</ion-checkbox>");
+$templateCache.put("fields/ion-input.html","<label class=\"item item-input\"><input ng-model=\"model[options.key]\" placeholder=\"{{options.templateOptions.placeholder}}\" type=\"{{options.templateOptions.type}}\"></label>");
+$templateCache.put("fields/ion-radio.html","<ion-radio ng-repeat=\"item in options.templateOptions.list\" ng-value=\"item.value\" ng-model=\"model[options.key]\">{{ item.text }}</ion-radio>");
+$templateCache.put("fields/ion-radio-ion-checkmark-balanced.html","<ion-radio icon=\"ion-checkmark balanced\" ng-repeat=\"item in options.templateOptions.list\" ng-value=\"item.value\" ng-model=\"model[options.key]\">{{ item.text }}</ion-radio>");
+$templateCache.put("fields/ion-range.html","<div class=\"item range\" ng-class=\"\'range-\' + options.templateOptions.rangeClass\"><span>{{options.templateOptions.label}}</span> <i class=\"icon\" ng-if=\"options.templateOptions.minIcon\" ng-class=\"options.templateOptions.minIcon\"></i> <input type=\"range\" min=\"{{options.templateOptions.min}}\" max=\"{{options.templateOptions.max}}\" step=\"{{options.templateOptions.step}}\" value=\"{{options.templateOptions.value}}\" ng-model=\"model[options.key]\"> <i class=\"icon\" ng-if=\"options.templateOptions.maxIcon\" ng-class=\"options.templateOptions.maxIcon\"></i></div>");
+$templateCache.put("fields/ion-textarea.html","<label class=\"item item-input\"><textarea placeholder=\"{{options.templateOptions.placeholder}}\" ng-model=\"model[options.key]\"></textarea></label>");
+$templateCache.put("fields/ion-toggle.html","<ion-toggle ng-model=\"model[options.key]\" toggle-class=\"toggle-{{options.templateOptions.toggleClass}}\">{{options.templateOptions.label}}</ion-toggle>");}]);


### PR DESCRIPTION
Hey, i know this isn't a neat solution but i needed them check marks to be green. I wanted to make it programmatically so that you can just specify any icon. But passing ionicon name programmatically through templateOptions and then doing something similar to what currently is happening

```
<ion-radio icon=\"item.icon\" ng-repeat=\"item in options.templateOptions.list\" ng-value=\"item.value\" ng-model=\"model[options.key]\">{{ item.text }}</ion-radio>"
```

The problem with the above is that the ionicon doesn't end up rendering. I guess by the time angular finishes interpolating the expression and decides to apply the class, it's already too late. Let me know what you think.
