### PR TITLE
Added Inline, Stacked and Floating Label options

### DIFF
--- a/src/fields/ion-input.html
+++ b/src/fields/ion-input.html
@@ -1,4 +1,5 @@
-<label class="item item-input">
+<label class="item item-input" ng-class="{'item-stacked-label': options.templateOptions.stackedLabel, 'item-floating-label':options.templateOptions.floatingLabel}">
   <i class="icon {{options.templateOptions.icon}}" ng-if="options.templateOptions.icon" ng-class="{'placeholder-icon': options.templateOptions.iconPlaceholder}"></i>
+  <span class="input-label" ng-show="options.templateOptions.inlineLabel" ng-class="{'has-input': model[options.key]}">{{options.templateOptions.inlineLabel}}</span>
   <input ng-model="model[options.key]" placeholder="{{options.templateOptions.placeholder}}" type="{{options.templateOptions.type}}">
 </label>


### PR DESCRIPTION
I just added this three Ionic options for Inputs because i need it on the project that i'm working
- Text Input: Inline Label with **inlineLabel** option (the value must be an String with the content to show)
- Text Input: Stacked Label (Require Inline Label) with **stackedLabel** option (Boolean)
- Text Input: Floating Label (Require Inline Label) with **floatingLabel** option (Boolean)

It's an example of how i use it:

```
{
  key: 'full_name',
  type: 'input',
   "templateOptions": {
        "type": "text",
        "placeholder": "Jorge Tapia",
        "label":"aer",
        "required":true,
        "inlineLabel": "Nombre y Apellido",
        "stackedLabel": false,
        "floatingLabel":true
      }
}
```

and it will produce something like this:

(just placeholder)
![captura de pantalla 2015-07-31 a las 20 46 21](https://cloud.githubusercontent.com/assets/116668/9019633/3f90a47a-37c5-11e5-9a91-cf9c5eaedbd5.png)

(with floating label)
![captura de pantalla 2015-07-31 a las 20 45 35](https://cloud.githubusercontent.com/assets/116668/9019624/26ba2db8-37c5-11e5-9d7f-209b2b3aa542.png)

I faced a little issue with floating labels, because for some reason the "has-input" class that is added when someone type something in the input wasn't working, so i added this to make this work:

`ng-class="{'has-input': model[options.key]}"`

I'm very new to AngularJS and ionic so i tried to write it right.
